### PR TITLE
feat: Create info pages and standardize footer

### DIFF
--- a/como-trabajamos.html
+++ b/como-trabajamos.html
@@ -54,9 +54,84 @@
         </header>
 
         <main class="container mx-auto px-6 py-12">
-            <h1 class="text-4xl font-bold mb-6">Cómo Trabajamos y Tiempos de Entrega</h1>
-            <div class="prose dark:prose-invert max-w-none">
-                <p>Contenido próximamente...</p>
+            <h1 class="text-4xl font-bold mb-6">Cómo Trabajamos en YAN'Z SMART WOOD</h1>
+            <div class="prose dark:prose-invert max-w-none space-y-8">
+
+                <p class="text-lg">En YAN'Z SMART WOOD, nos dedicamos a materializar tus ideas, ya sea creando muebles únicos que transforman tus espacios, proveyéndote los materiales que tus proyectos necesitan con agilidad, o construyendo la presencia digital que tu marca merece. Para garantizar tu total satisfacción, nuestros procesos son claros, transparentes y adaptados a cada servicio.</p>
+
+                <div>
+                    <h2 class="text-3xl font-bold border-b border-gray-700 pb-2 mb-4">1. Proceso para Muebles a Medida (Servicio en Quito y Valles)</h2>
+                    <h3 class="text-xl font-semibold mt-4">Paso 1: Consulta y Diseño Inicial (1-3 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Contáctanos:</strong> El proceso comienza cuando nos cuentas tu idea. Agendaremos una visita técnica en tu domicilio (o una videollamada) para tomar medidas, discutir materiales, acabados y entender a fondo tu visión.</li>
+                        <li><strong>Propuesta de Diseño:</strong> Con toda la información, nuestro equipo creará un diseño 3D y una cotización detallada.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold mt-4">Paso 2: Aprobación y Abono (1-2 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Revisión del Diseño:</strong> Te presentamos la propuesta y realizamos los ajustes necesarios hasta que estés 100% satisfecho.</li>
+                        <li><strong>Confirmación del Pedido:</strong> Para iniciar la fabricación, solicitamos un abono del 50% del valor total del proyecto.</li>
+                    </ul>
+
+                    <h3 class="text-xl font-semibold mt-4">Paso 3: Fabricación en Taller y Entrega (15-20 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Manos a la Obra:</strong> Nuestro equipo de expertos comienza la fabricación de tus muebles en nuestro taller, usando materiales de primera y maquinaria de precisión.</li>
+                        <li><strong>Instalación y Pago Final:</strong> Una vez listos, coordinamos la entrega e instalación. El 50% restante se cancela al finalizar la instalación, una vez que verificas que todo está en perfecto estado.</li>
+                    </ul>
+                    <p class="mt-4 font-semibold">Tiempo de Entrega Estimado para Muebles: El tiempo total desde la confirmación del pedido hasta la instalación es de aproximadamente 20 a 25 días hábiles.</p>
+                </div>
+
+                <div>
+                    <h2 class="text-3xl font-bold border-b border-gray-700 pb-2 mb-4">2. Proceso para Sección Ferretería (Entregas en Quito y Valles)</h2>
+                    <h3 class="text-xl font-semibold mt-4">Disponibilidad Garantizada</h3>
+                    <p>Para asegurarte la más amplia gama de productos, trabajamos con nuestro inventario propio y una sólida red de proveedores aliados. Si no lo tenemos, ¡lo conseguimos por ti!</p>
+
+                    <h3 class="text-xl font-semibold mt-4">Proceso de Compra y Entrega: Rápido y a tu Ritmo</h3>
+                    <p>Gracias a nuestro sistema automatizado, puedes realizar tus pedidos a cualquier hora del día, los 7 días de la semana. Una vez que recibimos la confirmación de tu pago, nuestro compromiso de entrega funciona así:</p>
+
+                    <h4 class="text-lg font-semibold mt-3">Nuestros Horarios de Entrega:</h4>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Lunes a Viernes:</strong>
+                            <ul class="list-disc list-inside ml-6">
+                                <li>Pedidos confirmados ANTES de las 2:00 PM: Haremos todo lo posible por entregar tu pedido esa misma tarde. Nuestra ventana de entrega se extiende hasta las 8:00 PM.</li>
+                                <li>Pedidos confirmados DESPUÉS de las 2:00 PM: Tu pedido será entregado con total prioridad al siguiente día laborable.</li>
+                            </ul>
+                        </li>
+                        <li><strong>Sábados:</strong>
+                            <ul class="list-disc list-inside ml-6">
+                                <li>Pedidos confirmados ANTES de las 11:00 AM: Gestionamos tu pedido para ser entregado durante la tarde del mismo sábado.</li>
+                                <li>Pedidos confirmados DESPUÉS de las 11:00 AM: Tu pedido será procesado el lunes a primera hora.</li>
+                            </ul>
+                        </li>
+                        <li><strong>Domingos y Feriados (Servicio Especial):</strong> Ofrecemos un servicio de entrega especial para domingos y feriados, sujeto a disponibilidad y con un costo de envío adicional. Contáctanos directamente para coordinar.</li>
+                    </ul>
+                     <p class="mt-4 font-semibold">Nuestro Compromiso Máximo: Te garantizamos que cada pedido será entregado en un plazo máximo de 24 horas laborables (Lunes a Sábado).</p>
+                </div>
+
+                <div>
+                    <h2 class="text-3xl font-bold border-b border-gray-700 pb-2 mb-4">3. Proceso para Soluciones Digitales (Servicio Global 100% Online)</h2>
+                    <p>Llevamos tu negocio al mundo digital a través de un proceso colaborativo, 100% online y enfocado en tus objetivos.</p>
+                    <h3 class="text-xl font-semibold mt-4">Paso 1: Reunión Inicial y Estrategia (1-2 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Conversamos:</strong> Agendamos una videollamada para conocer a fondo tu negocio, tus clientes y tus metas.</li>
+                        <li><strong>Definimos el Plan:</strong> Trazamos la estructura de la página web o catálogo y la estrategia para comunicar tu mensaje de forma efectiva a tu audiencia.</li>
+                    </ul>
+                    <h3 class="text-xl font-semibold mt-4">Paso 2: Diseño y Propuesta Visual (3-5 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Creamos el Diseño:</strong> Nuestro equipo diseña una propuesta visual (mockup) de cómo se verá y sentirá tu sitio web.</li>
+                        <li><strong>Revisión y Ajustes:</strong> Te presentamos el diseño para tu revisión. Realizamos los cambios necesarios hasta que estés completamente conforme.</li>
+                    </ul>
+                    <h3 class="text-xl font-semibold mt-4">Paso 3: Desarrollo y Construcción (7-10 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Damos Vida al Proyecto:</strong> Una vez aprobado el diseño, procedemos con la construcción del sitio web, integrando tus contenidos y las funcionalidades acordadas.</li>
+                    </ul>
+                    <h3 class="text-xl font-semibold mt-4">Paso 4: Lanzamiento y Entrega (1-2 días hábiles)</h3>
+                    <ul class="list-disc list-inside space-y-2 mt-2">
+                        <li><strong>Revisión Final:</strong> Te presentamos el sitio web completamente funcional para una última revisión.</li>
+                        <li><strong>Lanzamiento:</strong> Con tu visto bueno, publicamos tu página web para que esté visible en todo el mundo.</li>
+                        <li><strong>Pequeña Capacitación:</strong> Te brindamos una breve capacitación virtual para que puedas gestionar el contenido básico de tu nuevo sitio.</li>
+                    </ul>
+                </div>
             </div>
         </main>
 


### PR DESCRIPTION
Adds three new static pages as requested: /como-trabajamos.html, /privacidad.html, and /terminos.html.

Populates the 'Cómo Trabajamos' page with user-provided content.

Updates the footer on all existing pages to use root-relative links to the new pages, ensuring they work from any level of the site.

Includes a fix in js/main.js to ensure pages without a preloader element (like these new ones) are rendered correctly.