### PR TITLE
feat: Update and populate terms and conditions page

### DIFF
--- a/terminos.html
+++ b/terminos.html
@@ -56,7 +56,58 @@
         <main class="container mx-auto px-6 py-12">
             <h1 class="text-4xl font-bold mb-6">Términos de Servicio</h1>
             <div class="prose dark:prose-invert max-w-none">
-                <p>Contenido próximamente...</p>
+                <p class="text-sm text-gray-500 mb-4">Última actualización: 16 de septiembre de 2025</p>
+                <p class="mb-6">Bienvenido a YAN'Z SMART WOOD. Al acceder y utilizar nuestro sitio web y solicitar nuestros servicios, usted ("el Cliente") acepta y se compromete a cumplir los siguientes términos y condiciones. Por favor, léalos detenidamente.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">1. Aceptación de los Términos</h2>
+                <p>El uso de este sitio web y la contratación de nuestros servicios constituyen la aceptación plena y sin reservas de todos y cada uno de los términos aquí expuestos. Si no está de acuerdo con estos términos, por favor no utilice nuestros servicios.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">2. Descripción de los Servicios</h2>
+                <p>YAN'Z SMART WOOD ofrece tres líneas de servicio principales:</p>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Diseño y Fabricación de Muebles a Medida:</strong> Creación de mobiliario personalizado.</li>
+                    <li><strong>Venta y Entrega de Materiales de Ferretería:</strong> Suministro de materiales para construcción y remodelación.</li>
+                    <li><strong>Soluciones Digitales:</strong> Creación de páginas web y catálogos digitales para negocios.</li>
+                </ul>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">3. Cotizaciones y Precios</h2>
+                <p>Todos nuestros servicios requieren una cotización previa. Las cotizaciones se basan en la información proporcionada por el Cliente y tienen una validez de 15 días, a menos que se especifique lo contrario.</p>
+                <p>Los precios son expresados en Dólares de los Estados Unidos (USD) y no incluyen el IVA, a menos que se indique explícitamente.</p>
+                <p>YAN'Z SMART WOOD se reserva el derecho de modificar los precios de los productos de ferretería sin previo aviso, aunque se respetarán los precios de las cotizaciones ya enviadas y dentro de su periodo de validez.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">4. Condiciones Específicas por Servicio</h2>
+
+                <h3 class="text-xl font-bold mt-6 mb-2">a) Para Muebles a Medida:</h3>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Abono y Pago:</strong> Para iniciar la fabricación de cualquier proyecto, se requiere un abono del 50% del valor total. El 50% restante deberá ser cancelado en su totalidad el día de la entrega e instalación del mueble.</li>
+                    <li><strong>Tiempos de Entrega:</strong> Los plazos de entrega son estimaciones (aproximadamente 20-25 días hábiles) y comenzarán a contar desde la fecha de confirmación del abono.</li>
+                    <li><strong>Materiales:</strong> El Cliente reconoce que los materiales naturales como la madera pueden tener ligeras variaciones de tono y veta, lo cual es parte de su carácter único y no se considerará un defecto.</li>
+                    <li><strong>Garantía:</strong> Nuestros muebles cuentan con una garantía de 1 año por defectos de fabricación, la cual no cubre daños causados por mal uso, desgaste normal, exposición a condiciones inadecuadas (humedad o calor excesivo) o reparaciones por parte de terceros.</li>
+                </ul>
+
+                <h3 class="text-xl font-bold mt-6 mb-2">b) Para la Sección de Ferretería:</h3>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Pago:</strong> Los pedidos de ferretería deben ser cancelados en su totalidad (100%) antes de ser despachados.</li>
+                    <li><strong>Disponibilidad:</strong> Hacemos nuestro mejor esfuerzo por mantener la disponibilidad de todos los productos. En caso de que un artículo no esté en stock, lo gestionaremos a través de nuestra red de proveedores para cumplir con la entrega.</li>
+                    <li><strong>Envíos:</strong> El costo del envío será especificado en la cotización y dependerá del volumen y destino del pedido. Los plazos de entrega están sujetos a las condiciones detalladas en nuestra sección "Cómo Trabajamos".</li>
+                </ul>
+
+                <h3 class="text-xl font-bold mt-6 mb-2">c) Para Soluciones Digitales:</h3>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Abono y Pago:</strong> Se requiere un abono del 50% para iniciar el proyecto. El 50% restante se cancelará al finalizar el desarrollo, justo antes del lanzamiento y entrega de los accesos finales.</li>
+                    <li><strong>Contenido:</strong> El Cliente es responsable de proporcionar todo el contenido necesario para el sitio web (textos, imágenes, logos) en los plazos acordados. Los retrasos en la entrega del contenido pueden afectar la fecha final de lanzamiento del proyecto.</li>
+                    <li><strong>Propiedad Intelectual:</strong> Una vez cancelado el 100% del proyecto, el Cliente es el propietario total del sitio web o catálogo digital. YAN'Z SMART WOOD se reserva el derecho de mostrar el trabajo realizado en su portafolio.</li>
+                </ul>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">5. Responsabilidad del Usuario</h2>
+                <p>El Cliente se compromete a proporcionar información veraz y precisa para la correcta prestación de los servicios. YAN'Z SMART WOOD no se responsabiliza por errores o retrasos derivados de información incorrecta o incompleta proporcionada por el Cliente.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">6. Modificación de los Términos</h2>
+                <p>YAN'Z SMART WOOD se reserva el derecho de modificar estos términos y condiciones en cualquier momento. Los cambios serán publicados en esta página y entrarán en vigor inmediatamente.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">7. Ley Aplicable y Jurisdicción</h2>
+                <p>Estos términos se regirán e interpretarán de acuerdo con las leyes de la República del Ecuador. Cualquier disputa se someterá a la jurisdicción de los tribunales competentes de la ciudad de Quito.</p>
+                <p class="mt-4">Para cualquier pregunta sobre estos términos, por favor contáctenos a través de nuestro correo electrónico.</p>
             </div>
         </main>
 


### PR DESCRIPTION
- Replaces the placeholder text on the `terminos.html` page with the official 'Términos y Condiciones' provided by the user.
- Formats the content using appropriate HTML tags (h2, h3, p, ul, li) to ensure readability and maintain the document's structure.
- Adds Tailwind CSS classes for styling consistent with the rest of the site.