### PR TITLE
feat: Populate privacy policy page

### DIFF
--- a/privacidad.html
+++ b/privacidad.html
@@ -56,7 +56,51 @@
         <main class="container mx-auto px-6 py-12">
             <h1 class="text-4xl font-bold mb-6">Políticas de Privacidad</h1>
             <div class="prose dark:prose-invert max-w-none">
-                <p>Contenido próximamente...</p>
+                <p class="text-sm text-gray-500 mb-4">Última actualización: 16 de septiembre de 2025</p>
+                <p class="mb-6">En YAN'Z SMART WOOD, tu privacidad es nuestra prioridad. Esta política describe de manera transparente qué datos recopilamos, por qué lo hacemos y cómo los protegemos, incluyendo el uso de tecnologías para publicidad y análisis. Al usar nuestro sitio web, aceptas las prácticas descritas en esta política.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">1. Responsable de tus Datos:</h2>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Nombre Comercial:</strong> YAN'Z SMART WOOD</li>
+                    <li><strong>Email de Contacto para Privacidad:</strong> yanzsmartwood@gmail.com</li>
+                    <li><strong>Ubicación:</strong> Quito, Ecuador</li>
+                </ul>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">2. ¿Qué Información Recopilamos?</h2>
+                <h3 class="text-xl font-bold mt-6 mb-2">a) Información que nos proporcionas directamente:</h3>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Datos de Contacto:</strong> Nombre, número de teléfono y correo electrónico cuando nos contactas.</li>
+                    <li><strong>Datos de Ubicación:</strong> Tu dirección para coordinar visitas, entregas e instalaciones.</li>
+                    <li><strong>Información del Proyecto:</strong> Detalles y especificaciones sobre tus cotizaciones.</li>
+                </ul>
+                <h3 class="text-xl font-bold mt-6 mb-2">b) Información que recopilamos automáticamente:</h3>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Cookies y Tecnologías Similares:</strong> Utilizamos cookies (pequeños archivos de texto guardados en tu navegador) para mejorar tu experiencia, analizar el rendimiento del sitio y, en el futuro, mostrar publicidad relevante.</li>
+                    <li><strong>Datos de Navegación:</strong> Información anónima como tu dirección IP, tipo de navegador, dispositivo y páginas que visitas en nuestro sitio.</li>
+                </ul>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">3. ¿Para Qué Usamos tu Información?</h2>
+                <ul class="list-disc list-inside space-y-2 mb-4">
+                    <li><strong>Para Proveer nuestros servicios:</strong> Procesar tus cotizaciones, fabricar tus productos y gestionar tus proyectos.</li>
+                    <li><strong>Para Comunicarnos contigo:</strong> Responder a tus consultas y coordinar la logística.</li>
+                    <li><strong>Para Mejorar nuestro Sitio Web:</strong> Analizar el tráfico y el comportamiento del usuario para optimizar la experiencia.</li>
+                    <li><strong>Para Fines Publicitarios (Importante):</strong> En el futuro, planeamos utilizar tu información de navegación anónima para mostrarte anuncios personalizados en nuestro sitio y en otros sitios web, a través de redes publicitarias como Google AdSense.</li>
+                </ul>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">4. Cookies y Publicidad de Terceros</h2>
+                <p>Para que nuestro sitio sea sostenible y para poder mostrarte ofertas relevantes, trabajamos con socios publicitarios.</p>
+                <p>Proveedores de Terceros, incluido Google, utilizan cookies para mostrar anuncios basados en tus visitas anteriores a nuestro sitio web o a otros sitios web.</p>
+                <p>El uso de cookies de publicidad por parte de Google permite a sus socios y a nosotros mostrar anuncios basados en tu navegación.</p>
+                <p>Puedes inhabilitar la publicidad personalizada. Si no deseas ver anuncios basados en tus intereses, puedes hacerlo visitando la <a href="https://www.google.com/settings/ads" target="_blank" class="text-teal-400 hover:underline">Configuración de Anuncios de Google</a>. Alternativamente, puedes visitar <a href="https://www.aboutads.info/choices/" target="_blank" class="text-teal-400 hover:underline">www.aboutads.info/choices/</a> para inhabilitar el uso de cookies de otros proveedores de terceros.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">5. ¿Compartimos tu Información?</h2>
+                <p>No vendemos ni alquilamos tus datos de contacto personales. Sin embargo, para que la publicidad y el análisis funcionen, compartimos datos de navegación anónimos con nuestros socios tecnológicos (como Google) a través de cookies.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">6. Tus Derechos como Titular de los Datos</h2>
+                <p>De acuerdo con la Ley de Protección de Datos del Ecuador, tienes derecho a acceder, rectificar, eliminar u oponerte al tratamiento de tus datos personales. Para ejercerlos, contáctanos a nuestro correo de privacidad.</p>
+
+                <h2 class="text-2xl font-bold mt-8 mb-4">7. Cambios en esta Política</h2>
+                <p>Nos reservamos el derecho de modificar esta política. Cualquier cambio será publicado en esta página.</p>
             </div>
         </main>
 


### PR DESCRIPTION
- Replaces the placeholder text on the `privacidad.html` page with the official 'Política de Privacidad' provided by the user.
- Formats the content using appropriate HTML tags (h2, h3, p, ul, li, a) to ensure readability and maintain the document's structure.
- Includes links to external resources for managing ad preferences.