### PR TITLE
feat: Add Open Graph tags for social media previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,21 @@
     
     <title>YAN'Z SMART WOOD - Diseño, Servicios y Tecnología IA</title>
     
-    <meta name="description" content="Diseño, tecnología y la nobleza de la madera para un estilo de vida moderno. Explora nuestros productos, servicios y soluciones con IA.">
-    <meta property="og:title" content="YAN'Z SMART WOOD - Diseño, Tecnología y Madera">
-    <meta property="og:description" content="Diseño, tecnología y la nobleza de la madera para un estilo de vida moderno. Explora nuestros productos y servicios.">
-    <meta property="og:image" content="https://yanz-smart-wood.vercel.app/assets/images/yanz-preview.png">
-    <meta property="og:url" content="https://yanz-smart-wood.vercel.app">
+    <meta name="description" content="Diseñamos y fabricamos muebles a medida, ofrecemos soluciones digitales y materiales de ferretería para tus proyectos.">
+
+    <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="YAN'Z SMART WOOD - Diseño, Tecnología y Madera">
-    <meta name="twitter:description" content="Diseño, tecnología y la nobleza de la madera para un estilo de vida moderno. Explora nuestros productos y servicios.">
-    <meta name="twitter:image" content="https://yanz-smart-wood.vercel.app/assets/images/yanz-preview.png">
+    <meta property="og:url" content="https://yanz-smart-wood.vercel.app/">
+    <meta property="og:title" content="YAN'Z SMART WOOD - Muebles a Medida y Soluciones Digitales">
+    <meta property="og:description" content="Diseñamos y fabricamos muebles a medida, ofrecemos soluciones digitales y materiales de ferretería para tus proyectos.">
+    <meta property="og:image" content="https://yanz-smart-wood.vercel.app/assets/images/Imagenes-presentacion/Presentacion-1.jpeg">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://yanz-smart-wood.vercel.app/">
+    <meta property="twitter:title" content="YAN'Z SMART WOOD - Muebles a Medida y Soluciones Digitales">
+    <meta property="twitter:description" content="Diseñamos y fabricamos muebles a medida, ofrecemos soluciones digitales y materiales de ferretería para tus proyectos.">
+    <meta property="twitter:image" content="https://yanz-smart-wood.vercel.app/assets/images/Imagenes-presentacion/Presentacion-1.jpeg">
 
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#1A202C">


### PR DESCRIPTION
- Updates the `<head>` of `index.html` with Open Graph (Facebook, WhatsApp) and Twitter Card meta tags.
- Sets the preview image to `assets/images/Imagenes-presentacion/Presentacion-1.jpeg` as requested.
- Includes a descriptive title and description for better link previews on social platforms.