### PR TITLE
Fix: Correct case for Closets video path

### DIFF
--- a/closets/index.html
+++ b/closets/index.html
@@ -71,7 +71,7 @@
                     <div class="mt-16 text-center">
                         <h3 class="text-2xl font-bold mb-6">Detalles en Movimiento</h3>
                         <video autoplay loop muted playsinline class="rounded-lg shadow-xl w-full max-w-4xl mx-auto">
-                            <source src="../assets/videos/closets.mp4" type="video/mp4">
+                            <source src="../assets/videos/Closets.mp4" type="video/mp4">
                             Tu navegador no soporta el video.
                         </video>
                     </div>


### PR DESCRIPTION
The video on the closets page was not loading because the file path in the HTML (`closets.mp4`) did not match the case of the actual filename (`Closets.mp4`).

This commit corrects the casing in the `src` attribute of the video tag in `closets/index.html` to ensure the video loads correctly on case-sensitive file systems.