### PR TITLE
fix(puertas): Correct case-sensitive video path

### DIFF
--- a/puertas/index.html
+++ b/puertas/index.html
@@ -72,7 +72,7 @@
                     <div class="mt-16 text-center">
                         <h3 class="text-2xl font-bold mb-6">Detalles en Movimiento</h3>
                         <video autoplay loop muted playsinline class="rounded-lg shadow-xl w-full max-w-4xl mx-auto">
-                            <source src="../assets/videos/puertas.mp4" type="video/mp4">
+                            <source src="../assets/videos/Puertas.mp4" type="video/mp4">
                             Tu navegador no soporta el video.
                         </video>
                     </div>


### PR DESCRIPTION
The video for the "puertas" section was not loading because the path in the HTML file (`puertas.mp4`) did not match the case of the actual filename (`Puertas.mp4`).

This commit corrects the `src` attribute in `puertas/index.html` to match the proper filename capitalization, ensuring the video displays correctly on case-sensitive systems.