### PR TITLE
Fix: Update materials section on closets page

### DIFF
--- a/closets/index.html
+++ b/closets/index.html
@@ -101,72 +101,76 @@
 
             <section id="materiales" class="py-20 section-bg">
                 <div class="container mx-auto px-6">
-                    <h2 class="text-3xl md:text-4xl font-bold text-center mb-12">Materiales con los que Trabajamos</h2>
+                    <h2 class="text-3xl md:text-4xl font-bold text-center mb-12">Materiales y Proceso</h2>
 
                     <div id="tabs-container" class="flex flex-wrap justify-center gap-2 mb-8">
-                        <button class="tab-button active py-2 px-5 rounded-full bg-[var(--yanz-bg)] hover:bg-[var(--yanz-primary)] hover:text-white transition-colors" data-tab="melaminico">Melamínico</button>
-                        <button class="tab-button py-2 px-5 rounded-full bg-[var(--yanz-bg)] hover:bg-[var(--yanz-primary)] hover:text-white transition-colors" data-tab="mdf">MDF Lacado</button>
-                        <button class="tab-button py-2 px-5 rounded-full bg-[var(--yanz-bg)] hover:bg-[var(--yanz-primary)] hover:text-white transition-colors" data-tab="termoformado">Termoformado</button>
-                        <button class="tab-button py-2 px-5 rounded-full bg-[var(--yanz-bg)] hover:bg-[var(--yanz-primary)] hover:text-white transition-colors" data-tab="mesones">Mesones</button>
+                        <button class="tab-button active py-2 px-5 rounded-full bg-[var(--yanz-bg)] hover:bg-[var(--yanz-primary)] hover:text-white transition-colors" data-tab="paneles">Paneles y Estructuras</button>
+                        <button class="tab-button py-2 px-5 rounded-full bg-[var(--yanz-bg)] hover:bg-[var(--yanz-primary)] hover:text-white transition-colors" data-tab="herrajes">Herrajes y Accesorios</button>
                     </div>
 
                     <div class="max-w-4xl mx-auto">
-                        <div id="melaminico" class="tab-content active">
+                        <div id="paneles" class="tab-content active">
                             <div class="bg-[var(--yanz-bg)] p-8 rounded-lg shadow-lg">
-                                <h3 class="text-2xl font-bold mb-4">Melamínico de Alta Resistencia</h3>
-                                <p class="text-[var(--yanz-text-alt)] mb-4">La melamina es un tablero de partículas de madera (aglomerado o MDF) recubierto por una lámina decorativa que simula maderas, colores sólidos o texturas. Es la opción más popular por su increíble balance entre durabilidad, variedad de diseños y costo.</p>
-                                <h4 class="font-bold mt-6 mb-2">Cuidados y Mantenimiento:</h4>
+                                <h3 class="text-2xl font-bold mb-4">MDF (Tablero de Fibra de Densidad Media)</h3>
+                                <p class="text-[var(--yanz-text-alt)] mb-4">El MDF es un tablero de ingeniería fabricado a partir de fibras de madera y resinas sintéticas, comprimidas a alta presión y temperatura. Su superficie es completamente lisa, uniforme y sin vetas, lo que lo convierte en la base perfecta para acabados de alta calidad.</p>
+                                <h4 class="font-bold mt-6 mb-2">Ventajas y Usos:</h4>
                                 <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
-                                    <li>Limpiar con un paño suave y húmedo con agua y jabón neutro.</li>
-                                    <li>Secar inmediatamente para evitar que la humedad penetre en las juntas.</li>
-                                    <li>No utilizar productos abrasivos, ceras o aerosoles.</li>
-                                    <li>Evitar el contacto directo con objetos muy calientes.</li>
+                                    <li>Acabados perfectos: Ideal para pintar, lacar o barnizar, logrando superficies sedosas y modernas.</li>
+                                    <li>Versatilidad: Se utiliza para puertas, frentes de cajón, molduras y estanterías, ya que permite cortes y diseños precisos.</li>
+                                    <li>Resistencia: Su alta densidad le confiere una buena resistencia estructural y evita que se doble con el tiempo.</li>
+                                </ul>
+                                <h4 class="font-bold mt-6 mb-2">Proceso de Trabajo y Consideraciones:</h4>
+                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
+                                    <li>Corte: Se corta fácilmente con herramientas de carpintería estándar (sierras de banco o circulares). Debido a su composición, genera un polvo muy fino, por lo que es indispensable usar equipo de protección respiratoria (mascarilla) y un buen sistema de extracción de polvo.</li>
+                                    <li>Ensamblaje: Para uniones firmes, se utilizan tornillos y pegamento para madera. Es crucial hacer una perforación guía (avellanado) antes de atornillar para evitar que el material se abombe o se agriete alrededor del tornillo.</li>
+                                    <li>Acabado de Cantos: Los cantos del MDF son porosos y absorben mucha pintura. Para un acabado profesional, primero se deben sellar. Esto se logra aplicando una capa de sellador, una mezcla de pegamento y agua, o masilla para madera. Una vez lijado, el canto queda liso y listo para pintar igual que la superficie.</li>
+                                    <li>Pintura y Lacado: Este es el punto fuerte del MDF. El proceso inicia con una capa de imprimación o sellador para preparar la superficie. Luego, se aplican varias capas finas de laca o pintura (generalmente con pistola para un acabado uniforme), lijando suavemente entre capa y capa. Este meticuloso proceso da como resultado un acabado perfectamente liso y duradero.</li>
+                                </ul>
+                                <h3 class="text-2xl font-bold mb-4 mt-8">Aglomerado y Melamina</h3>
+                                <p class="text-[var(--yanz-text-alt)] mb-4">El aglomerado es un tablero formado por partículas de madera unidas con resina. La versión más popular y recomendada para closets es el aglomerado recubierto con melamina, una lámina decorativa que se fusiona al tablero, ofreciendo durabilidad y una gran variedad de diseños.</p>
+                                <h4 class="font-bold mt-6 mb-2">Ventajas y Usos:</h4>
+                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
+                                    <li>Costo-Beneficio: Es una opción más económica que el MDF o la madera maciza.</li>
+                                    <li>Durabilidad: La capa de melamina ofrece una excelente protección contra rayones, manchas y la humedad superficial.</li>
+                                    <li>Variedad de Diseños: Disponible en una infinita gama de colores sólidos, texturas y acabados que imitan madera, mármol o cemento.</li>
+                                </ul>
+                                <h4 class="font-bold mt-6 mb-2">Proceso de Trabajo y Consideraciones:</h4>
+                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
+                                    <li>Corte: El corte de la melamina requiere una técnica precisa para no dañar el acabado. Se utiliza una sierra con un disco de alto número de dientes (más de 80) y, preferiblemente, con un incisor que realiza un pre-corte para evitar que la melamina se astille o despostille, garantizando un borde limpio.</li>
+                                    <li>Canteado: A diferencia del MDF, los cantos del aglomerado no se pintan. Se cubren con un "tapacantos" o "cubrecanto" de PVC o melamina, que es una cinta del mismo color y textura que la superficie. Este se adhiere con un pegamento especial mediante una máquina canteadora industrial que aplica calor y presión, asegurando una unión perfecta y duradera que sella el tablero.</li>
+                                    <li>Ensamblaje: Se ensambla principalmente con tornillos especiales (como los "confirmat") que tienen una rosca más agresiva para un mejor agarre en las partículas. También se utilizan sistemas de ensamblaje oculto como el "minifix", que permiten unir las piezas sin que se vean tornillos desde el exterior, un detalle clave en muebles modernos.</li>
+                                    <li>Mantenimiento: El trabajo principal está en la fabricación. Una vez instalado, su mantenimiento es simple: se limpia con un paño húmedo y no requiere pintura ni tratamientos adicionales.</li>
                                 </ul>
                             </div>
                         </div>
-                        <div id="mdf" class="tab-content">
+                        <div id="herrajes" class="tab-content">
                             <div class="bg-[var(--yanz-bg)] p-8 rounded-lg shadow-lg">
-                                <h3 class="text-2xl font-bold mb-4">MDF Lacado: Acabado Premium</h3>
-                                <p class="text-[var(--yanz-text-alt)] mb-4">El MDF (tablero de fibra de densidad media) es una base excelente para la pintura lacada. Este proceso consiste en aplicar múltiples capas de laca de alta calidad para lograr una superficie perfectamente lisa, uniforme y de gran elegancia. Permite cualquier color y acabado (mate, satinado o brillante).</p>
-                                <h4 class="font-bold mt-6 mb-2">Cuidados y Mantenimiento:</h4>
+                                <h3 class="text-2xl font-bold mb-4">Rieles y Correderas</h3>
+                                <p class="text-[var(--yanz-text-alt)] mb-4">Son el mecanismo que permite que los cajones se deslicen. La calidad del riel define la experiencia de uso diario del closet.</p>
+                                <h4 class="font-bold mt-6 mb-2">Proceso de Trabajo y Consideraciones:</h4>
                                 <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
-                                    <li>Usar un paño de microfibra suave, ligeramente humedecido.</li>
-                                    <li>Evitar golpes y rayones, ya que la reparación es más compleja.</li>
-                                    <li>No usar limpiadores con alcohol, amoníaco o disolventes.</li>
-                                    <li>El color puede ser sensible a la exposición prolongada a la luz solar directa.</li>
+                                    <li>Instalación: Constan de dos partes: una se atornilla a la pared lateral del mueble y la otra al lateral del cajón. La clave está en la precisión. Se deben instalar perfectamente nivelados y paralelos entre sí. Un milímetro de desfase puede hacer que el cajón se atore o no cierre correctamente.</li>
+                                    <li>Medición: Antes de construir el cajón, se debe conocer el descuento que requiere la corredera. Por lo general, se necesita dejar un espacio de 1/2 pulgada (1.27 cm) a cada lado del cajón para el mecanismo.</li>
+                                    <li>Ajustes: Las correderas de buena calidad incluyen mecanismos de ajuste que permiten mover el frente del cajón ligeramente hacia arriba/abajo o adentro/afuera después de la instalación. Esto es vital para lograr una alineación visual perfecta entre todos los frentes de cajón.</li>
+                                </ul>
+                                <h3 class="text-2xl font-bold mb-4 mt-8">Bisagras</h3>
+                                <p class="text-[var(--yanz-text-alt)] mb-4">Las bisagras de cazoleta son el estándar de la industria para puertas de closets modernos, quedando ocultas y permitiendo un ajuste fino.</p>
+                                <h4 class="font-bold mt-6 mb-2">Proceso de Trabajo y Consideraciones:</h4>
+                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
+                                    <li>Perforación: La instalación de la bisagra en la puerta requiere una perforación circular específica, llamada cazoleta. Se realiza con una broca especial tipo "Forstner" (generalmente de 35 mm de diámetro) a una profundidad exacta para que la bisagra quede a ras.</li>
+                                    <li>Montaje: La bisagra se compone de dos partes: la cazoleta que va en la puerta y la base que se atornilla al lateral del mueble. Una vez instaladas ambas partes, la puerta simplemente se "clipea" en su lugar.</li>
+                                    <li>Alineación de Puertas: Su principal ventaja es la capacidad de ajuste tridimensional. Mediante tres tornillos diferentes en la bisagra, se puede regular la altura, la profundidad y la posición lateral de la puerta. Este proceso es el que permite que todas las puertas del closet queden perfectamente alineadas, con una separación uniforme entre ellas.</li>
+                                </ul>
+                                <h3 class="text-2xl font-bold mb-4 mt-8">Jaladeras y Tiradores</h3>
+                                <p class="text-[var(--yanz-text-alt)] mb-4">Son el detalle final que define el estilo del closet. Su instalación debe ser precisa para mantener la simetría y la estética.</p>
+                                <h4 class="font-bold mt-6 mb-2">Proceso de Trabajo y Consideraciones:</h4>
+                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
+                                    <li>Uso de Plantillas (Jigs): Para asegurar que todas las jaladeras queden exactamente en la misma posición en múltiples puertas o cajones, los profesionales usan plantillas de instalación. Estas guías plásticas o metálicas marcan el punto exacto donde se debe perforar, garantizando consistencia y evitando errores de medición.</li>
+                                    <li>Perforación Limpia: La perforación se hace desde la cara frontal de la puerta hacia el interior. Para evitar astillar el material en la cara interna al salir la broca, se recomienda colocar un trozo de madera de desecho presionado firmemente contra esa cara.</li>
+                                    <li>Sistemas Integrados: En los diseños minimalistas que usan perfiles tipo "Gola", estos perfiles de aluminio se deben cortar a medida e integrar en la estructura del mueble durante el ensamblaje, ya que forman parte de la propia caja del closet.</li>
                                 </ul>
                             </div>
                         </div>
-                        <div id="termoformado" class="tab-content">
-                            <div class="bg-[var(--yanz-bg)] p-8 rounded-lg shadow-lg">
-                                <h3 class="text-2xl font-bold mb-4">Termoformado: Diseño Sin Juntas</h3>
-                                <p class="text-[var(--yanz-text-alt)] mb-4">Este material consiste en un folio de PVC que se calienta y se adhiere al vacío sobre un tablero de MDF. Su gran ventaja es que recubre las caras y los cantos en una sola pieza, eliminando las juntas y creando un acabado continuo, moderno y muy fácil de limpiar.</p>
-                                <h4 class="font-bold mt-6 mb-2">Cuidados y Mantenimiento:</h4>
-                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
-                                    <li>Limpieza sencilla con agua y jabón.</li>
-                                    <li>Muy resistente a la humedad y las manchas.</li>
-                                    <li>Evitar fuentes de calor excesivo y directo (como tostadoras u ollas calientes) que podrían dañar el PVC.</li>
-                                    <li>Resistente a los productos de limpieza habituales, pero evitar abrasivos.</li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div id="mesones" class="tab-content">
-                            <div class="bg-[var(--yanz-bg)] p-8 rounded-lg shadow-lg">
-                                <h3 class="text-2xl font-bold mb-4">Mesones: Granito y Cuarzo</h3>
-                                <p class="text-[var(--yanz-text-alt)] mb-4">La superficie de trabajo es clave. Ofrecemos los dos materiales más demandados: el **Granito**, una piedra natural única, duradera y resistente al calor; y el **Cuarzo**, un material de ingeniería extremadamente duro, no poroso y con una consistencia de color y patrón superior.</p>
-                                 <h4 class="font-bold mt-6 mb-2">Cuidados y Mantenimiento:</h4>
-                                <ul class="list-disc list-inside text-[var(--yanz-text-alt)] space-y-1">
-                                    <li>**Granito:** Requiere sellado periódico (anual) para evitar manchas. Limpiar derrames rápidamente.</li>
-                                    <li>**Cuarzo:** No requiere sellado. Muy resistente a las manchas y las bacterias.</li>
-                                    <li>Ambos se limpian fácilmente con agua y jabón.</li>
-                                    <li>Usar siempre tablas de cortar para proteger la superficie y sus cuchillos.</li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mt-12 p-4 bg-yellow-100 dark:bg-yellow-900/50 text-yellow-800 dark:text-yellow-200 rounded-lg text-center max-w-4xl mx-auto">
-                        <p class="font-semibold">Nota Importante Sobre los Colores:</p>
-                        <p class="text-sm">Las muestras de colores y texturas de nuestros materiales son una guía de referencia. Debido a variaciones naturales en la madera y procesos de fabricación, los tonos pueden cambiar ligeramente con el tiempo o entre diferentes lotes. Recomendamos ver muestras físicas para la selección final.</p>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
- Reverted the materials section to its original state.
- Updated the materials section with the correct content provided by the user.
- The new section has two tabs: "Paneles y Estructuras" and "Herrajes y Accesorios".
- Re-applied the video background and Swiper carousel changes that were reverted by mistake.