### PR TITLE
feat: Standardize hero sections and refactor UI logic

### DIFF
--- a/banos/index.html
+++ b/banos/index.html
@@ -49,13 +49,11 @@
         </header>
 
         <main>
-            <section class="relative h-[50vh] flex items-center justify-center text-white">
-                <div class="absolute inset-0 bg-black/60 z-10"></div>
-                <img src="https://placehold.co/1920x1080/A0AEC0/FFFFFF?text=Muebles+de+Baño+Modernos" alt="Banner de un baño moderno y elegante" class="absolute inset-0 w-full h-full object-cover">
-                <div class="relative z-20 text-center px-4">
-                    <h1 class="text-4xl md:text-6xl font-bold tracking-tight">Muebles de Baño</h1>
-                    <p class="max-w-2xl mx-auto text-lg md:text-xl opacity-90 mt-4">Transforma tu baño en un santuario de relajación y elegancia.</p>
-                </div>
+            <section class="relative w-full h-screen">
+                <video autoplay loop muted playsinline class="absolute top-0 left-0 w-full h-full object-cover">
+                    <source src="../assets/videos/banos.mp4" type="video/mp4">
+                    Tu navegador no soporta el video.
+                </video>
             </section>
             
             <section class="py-20"><div class="container mx-auto px-6"><h2 class="text-3xl md:text-4xl font-bold text-center mb-12">Galería de Inspiración</h2><div class="grid grid-cols-2 md:grid-cols-4 gap-4"><div class="grid gap-4"><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x800/2D3748/FFFFFF?text=Vanity+1" alt=""></div><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x500/A0AEC0/FFFFFF?text=Detalle" alt=""></div></div><div class="grid gap-4"><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x500/4A5568/FFFFFF?text=Espejo" alt=""></div><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x800/718096/FFFFFF?text=Vanity+2" alt=""></div></div><div class="grid gap-4"><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x800/2D3748/FFFFFF?text=Vanity+3" alt=""></div><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x500/A0AEC0/FFFFFF?text=Organizador" alt=""></div></div><div class="grid gap-4"><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x500/4A5568/FFFFFF?text=Lavabo" alt=""></div><div><img class="h-auto max-w-full rounded-lg shadow-lg hover:scale-105 transition-transform" src="https://placehold.co/500x800/718096/FFFFFF?text=Vanity+4" alt=""></div></div></div></div></section>

--- a/ferreteria/index.html
+++ b/ferreteria/index.html
@@ -151,16 +151,8 @@
         </header>
 
         <main>
-            <section class="relative h-[50vh] flex items-center justify-center text-white">
-                <div class="absolute inset-0 bg-black/60 z-10"></div>
-                <video autoplay loop muted playsinline class="absolute inset-0 w-full h-full object-cover"><source src="https://storage.googleapis.com/yanz-smart-wood/assets/videos/ferreteria.mp4" type="video/mp4"></video>
-                
-                <div class="relative z-20 text-center px-4 flex justify-center">
-                    <video autoplay loop muted playsinline class="max-w-3xl w-full h-auto">
-                        <source src="https://storage.googleapis.com/yanz-smart-wood/assets/videos/titulo-ferreteria.mp4" type="video/mp4">
-                        <h1 class="text-4xl md:text-6xl font-bold tracking-tight mb-4 text-white">Ferretería Profesional</h1>
-                    </video>
-                </div>
+            <section class="relative w-full h-screen">
+                <video autoplay loop muted playsinline class="absolute top-0 left-0 w-full h-full object-cover"><source src="https://storage.googleapis.com/yanz-smart-wood/assets/videos/ferreteria.mp4" type="video/mp4"></video>
             </section>
             
             <section id="aria-search" class="py-16">

--- a/granitos/index.html
+++ b/granitos/index.html
@@ -49,13 +49,8 @@
         </header>
 
         <main>
-            <section class="relative h-[50vh] flex items-center justify-center text-white">
-                <div class="absolute inset-0 bg-black/60 z-10"></div>
-                <img src="https://placehold.co/1200x600/5d4037/ffffff?text=Meson+de+Granito" alt="[Banner de un elegante meson de granito en una cocina]" class="absolute inset-0 w-full h-full object-cover">
-                <div class="relative z-20 text-center px-4">
-                    <h1 class="text-4xl md:text-6xl font-bold tracking-tight">Granitos y Mesones</h1>
-                    <p class="max-w-2xl mx-auto text-lg md:text-xl opacity-90 mt-4">Superficies que combinan belleza natural y resistencia para tu hogar.</p>
-                </div>
+            <section class="relative w-full h-screen">
+                <img src="../assets/images/Granitos/Granito-1.jpeg" alt="Elegante meson de granito en una cocina" class="absolute inset-0 w-full h-full object-cover">
             </section>
 
             <section id="galeria" class="py-20">

--- a/gypsum/index.html
+++ b/gypsum/index.html
@@ -49,16 +49,11 @@
         </header>
 
         <main>
-            <section id="hero-gypsum" class="relative h-[50vh] flex items-center justify-center text-white">
-                <div class="absolute inset-0 bg-black/60 z-10"></div>
-                <video autoplay loop muted playsinline class="absolute inset-0 w-full h-full object-cover">
+            <section class="relative w-full h-screen">
+                <video autoplay loop muted playsinline class="absolute top-0 left-0 w-full h-full object-cover">
                     <source src="../assets/videos/gypsum-luz.mp4" type="video/mp4">
-                    Tu navegador no soporta videos.
+                    Tu navegador no soporta el video.
                 </video>
-                <div class="relative z-20 text-center px-4">
-                    <h1 class="text-4xl md:text-6xl font-bold tracking-tight mb-4">Gypsum y Luz</h1>
-                    <p class="max-w-2xl mx-auto text-lg md:text-xl opacity-90">Creamos atmósferas únicas, moldeando espacios y esculpiendo con luz para dar vida a tus ideas.</p>
-                </div>
             </section>
 
             <section id="tipos-gypsum" class="py-20 section-bg">

--- a/index.html
+++ b/index.html
@@ -82,12 +82,6 @@
                     <img src="assets/images/Imagenes-presentacion/Presentacion-9.jpeg" alt="Presentacion 9" class="hero-slide">
                     <img src="assets/images/Imagenes-presentacion/Presentacion-10.jpeg" alt="Presentacion 10" class="hero-slide">
                 </div>
-                <div class="relative z-20 text-center px-4">
-                    <video autoplay loop muted playsinline class="w-48 md:w-64 mx-auto mb-6">
-                        <source src="assets/videos/videologo4segundos.mp4" type="video/mp4">
-                    </video>
-                    <h1 class="text-4xl md:text-6xl font-bold tracking-tight mb-4">YAN'Z SMART WOOD</h1>
-                </div>
             </section>
             <section id="productos" class="py-20 section-bg"><div class="container mx-auto px-6"><h2 class="text-3xl md:text-4xl font-bold text-center mb-12">Explora Nuestros Productos</h2><div id="product-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"></div></div></section>
             <section id="servicios" class="py-20"><div class="container mx-auto px-6"><h2 class="text-3xl md:text-4xl font-bold text-center mb-12">Conoce Nuestros Servicios</h2><div id="service-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div></div></section>

--- a/pisos/index.html
+++ b/pisos/index.html
@@ -49,17 +49,11 @@
         </header>
 
         <main>
-            <!-- HERO SECTION PARA PISOS -->
-            <section id="hero-pisos" class="relative h-[50vh] flex items-center justify-center text-white">
-                <div class="absolute inset-0 bg-black/60 z-10"></div>
-                <video autoplay loop muted playsinline class="absolute inset-0 w-full h-full object-cover">
+            <section class="relative w-full h-screen">
+                <video autoplay loop muted playsinline class="absolute top-0 left-0 w-full h-full object-cover">
                     <source src="../assets/videos/pisos.mp4" type="video/mp4">
-                    Tu navegador no soporta videos.
+                    Tu navegador no soporta el video.
                 </video>
-                <div class="relative z-20 text-center px-4">
-                    <h1 class="text-4xl md:text-6xl font-bold tracking-tight mb-4">Pisos SPC</h1>
-                    <p class="max-w-2xl mx-auto text-lg md:text-xl opacity-90">La calidez de la madera con la resistencia del futuro. Belleza que perdura en cada paso.</p>
-                </div>
             </section>
 
             <!-- SECCIÓN DE TIPOS DE PISOS SPC -->


### PR DESCRIPTION
This commit implements a major UI overhaul to standardize the hero sections across all main category pages and refactors key JavaScript components for better maintainability and to fix a persistent UI bug.

Key Changes:
- Standardized Hero Sections: Removed text and dark overlays from the hero sections of `index.html`, `puertas/`, `pisos/`, `banos/`, `gypsum/`, `granitos/`, and `ferreteria/` pages. Hero sections now feature a clean, full-screen video or image slideshow.
- JavaScript Refactoring: Centralized the logic for tabbed interfaces and Swiper carousels into `js/main.js`.
- Removed Redundant Code: Deleted duplicated inline scripts from `puertas/`, `cocinas/`, and `closets/` pages.
- Bug Fix: The centralization of the tab logic resolves the issue where the 'active' state of material buttons was not persisting correctly.

This work also includes the previously implemented features for the `puertas` page, such as renaming images, adding the carousel, and updating material descriptions.