### PR TITLE
fix: Fine-tune video overlay size and position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,14 +136,14 @@ html { scroll-behavior: smooth; }
 }
 
 #computer-screen-carousel {
-    top: 17%;
+    top: 15%; /* Moved up */
     left: 17.5%;
-    width: 38%;
-    height: 48%;
+    width: 19%; /* Halved */
+    height: 24%; /* Halved */
 }
 
 #ipad-profile-pic {
-    top: 43%;
+    top: 41%; /* Moved up */
     left: 61%;
     width: 13%;
     height: 24%;


### PR DESCRIPTION
This commit adjusts the CSS for the dynamic video overlays based on user feedback for a more precise layout.

- The carousel container on the computer screen has been reduced to half its original size.
- Both the carousel and the profile picture overlays have been moved up slightly to better align with the elements in the video.