### PR TITLE
Feat: Add improved interactive tool for video overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
 </head>
 <body class="antialiased">
     <div id="preloader">
@@ -150,5 +151,17 @@
 
     <!-- Main Application Engine -->
     <script src="js/main.js?v=2"></script>
+
+    <!-- Panel de control interactivo para desarrollador -->
+    <div id="interactive-panel" style="position: fixed; top: 10px; left: 10px; background: rgba(0,0,0,0.8); color: white; padding: 15px; border-radius: 8px; z-index: 10000; font-family: monospace; font-size: 14px; border: 1px solid #444; backdrop-filter: blur(5px);">
+        <h4 style="margin: 0 0 10px 0; font-weight: bold; border-bottom: 1px solid #555; padding-bottom: 5px;">Valores Proporcionales</h4>
+        <div style="display: grid; grid-template-columns: 80px 1fr; gap: 5px;">
+            <strong>Top:</strong> <span id="val-top">0</span>
+            <strong>Left:</strong> <span id="val-left">0</span>
+            <strong>Width:</strong> <span id="val-width">0</span>
+            <strong>Height:</strong> <span id="val-height">0</span>
+        </div>
+        <button id="copy-values-btn" style="margin-top: 15px; width: 100%; padding: 8px 10px; background: #007bff; color: white; border: none; border-radius: 5px; cursor: pointer; font-weight: bold;">Copiar Valores</button>
+    </div>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -974,7 +974,7 @@ videosToLazyLoad.forEach(video => videoObserver.observe(video));
                 perspective: 500, rotateY: 2, rotateX: -2, skewX: -2
             };
             const ipad = {
-                bottom: 0.06, left: 0.6111, width: 0.1613, height: 0.2969
+                bottom: 0.06, left: 0.665, width: 0.166, height: 0.342
             };
 
             // Apply styles to Monitor
@@ -985,11 +985,12 @@ videosToLazyLoad.forEach(video => videoObserver.observe(video));
             monitorOverlay.style.transform = `translateX(-50%) perspective(${monitor.perspective}px) rotateY(${monitor.rotateY}deg) rotateX(${monitor.rotateX}deg) skewX(${monitor.skewX}deg)`;
 
             // Apply styles to iPad
-            ipadOverlay.style.bottom = `${containerHeight * ipad.bottom}px`;
-            ipadOverlay.style.left = `${containerWidth * ipad.left}px`;
-            ipadOverlay.style.width = `${containerWidth * ipad.width}px`;
-            ipadOverlay.style.height = `${containerHeight * ipad.height}px`;
-            ipadOverlay.style.transform = `translateX(-50%)`;
+            // Comentado para la herramienta de ajuste interactivo
+            // ipadOverlay.style.bottom = `${containerHeight * ipad.bottom}px`;
+            // ipadOverlay.style.left = `${containerWidth * ipad.left}px`;
+            // ipadOverlay.style.width = `${containerWidth * ipad.width}px`;
+            // ipadOverlay.style.height = `${containerHeight * ipad.height}px`;
+            // ipadOverlay.style.transform = `translateX(-50%)`;
         }
 
         // Initial positioning
@@ -1036,4 +1037,110 @@ videosToLazyLoad.forEach(video => videoObserver.observe(video));
             speakText(welcomeMessage);
         }, 1500);
     }
+
+    function makeIpadOverlayInteractive() {
+        const videoContainer = document.querySelector('#caja .overflow-hidden');
+        const targetElement = document.getElementById('ipad-overlay');
+
+        if (!interact || !targetElement || !videoContainer) {
+            console.log("Herramienta interactiva no iniciada: Elementos faltantes (interact.js, #ipad-overlay, o video container).");
+            return;
+        }
+
+        const valTop = document.getElementById('val-top');
+        const valLeft = document.getElementById('val-left');
+        const valWidth = document.getElementById('val-width');
+        const valHeight = document.getElementById('val-height');
+        const copyBtn = document.getElementById('copy-values-btn');
+
+        // Establecer un estilo inicial para que el elemento sea visible y manipulable
+        Object.assign(targetElement.style, {
+            top: '50%',
+            left: '50%',
+            width: '25%',
+            height: '40%',
+            transform: 'translate(-50%, -50%)',
+            border: '2px dashed #00f',
+            touchAction: 'none'
+        });
+
+        function updateDisplay() {
+            const containerRect = videoContainer.getBoundingClientRect();
+            const targetRect = targetElement.getBoundingClientRect();
+
+            const top = targetRect.top - containerRect.top;
+            const left = targetRect.left - containerRect.left;
+            const width = targetRect.width;
+            const height = targetRect.height;
+
+            valTop.textContent = (top / containerRect.height).toFixed(4);
+            valLeft.textContent = (left / containerRect.width).toFixed(4);
+            valWidth.textContent = (width / containerRect.width).toFixed(4);
+            valHeight.textContent = (height / containerRect.height).toFixed(4);
+        }
+
+        interact(targetElement)
+            .draggable({
+                listeners: {
+                    move(event) {
+                        const target = event.target;
+                        const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+                        const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+                        target.style.transform = `translate(${x}px, ${y}px)`;
+                        target.setAttribute('data-x', x);
+                        target.setAttribute('data-y', y);
+
+                        updateDisplay();
+                    }
+                },
+                modifiers: [
+                    interact.modifiers.restrictRect({
+                        restriction: 'parent',
+                    })
+                ],
+                inertia: false
+            })
+            .resizable({
+                edges: { left: true, right: true, bottom: true, top: true },
+                listeners: {
+                    move(event) {
+                        const target = event.target;
+                        let x = (parseFloat(target.getAttribute('data-x')) || 0);
+                        let y = (parseFloat(target.getAttribute('data-y')) || 0);
+
+                        target.style.width = `${event.rect.width}px`;
+                        target.style.height = `${event.rect.height}px`;
+
+                        x += event.deltaRect.left;
+                        y += event.deltaRect.top;
+
+                        target.style.transform = `translate(${x}px, ${y}px)`;
+                        target.setAttribute('data-x', x);
+                        target.setAttribute('data-y', y);
+
+                        updateDisplay();
+                    }
+                },
+                modifiers: [
+                    interact.modifiers.restrictEdges({
+                        outer: 'parent'
+                    }),
+                ],
+                inertia: false
+            });
+
+        updateDisplay();
+
+        copyBtn.addEventListener('click', () => {
+            const values = `top: ${valTop.textContent},\nleft: ${valLeft.textContent},\nwidth: ${valWidth.textContent},\nheight: ${valHeight.textContent}`;
+            navigator.clipboard.writeText(values);
+            copyBtn.textContent = '¡Copiado!';
+            setTimeout(() => { copyBtn.textContent = 'Copiar Valores'; }, 1500);
+        });
+
+        console.log("Herramienta interactiva para #ipad-overlay iniciada.");
+    }
+
+    makeIpadOverlayInteractive();
 });


### PR DESCRIPTION
This commit introduces a new and improved version of the interactive tool for adjusting the video overlay element.

Key improvements:
- The draggable and resizable area is now strictly confined to the parent video container, preventing the element from moving out of bounds.
- The position and dimension values displayed are now correctly calculated relative to the container, ensuring accurate measurements.
- The original positioning logic has been temporarily disabled to allow the tool to function without conflicts.

This version should provide a reliable way for the user to find the precise coordinates for the final layout.