### PR TITLE
Feat: Add final 3D frames and lights to video overlays

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -132,12 +132,45 @@ html { scroll-behavior: smooth; }
     display: flex;
     justify-content: center;
     align-items: center;
-    overflow: hidden;
+    overflow: visible; /* Permitir que las luces del pseudo-elemento se vean fuera */
     background-color: #000;
+    border: 3px solid #111;
+    box-shadow: inset 0 0 5px rgba(0,0,0,0.7), 0 5px 15px rgba(0,0,0,0.4);
 }
 
 #monitor-overlay {
     transform-origin: center center;
+    border-radius: 12px;
+}
+
+#ipad-overlay {
+    border-radius: 18px;
+}
+
+#monitor-overlay::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 25%;
+    height: 3px;
+    background-color: white;
+    border-radius: 3px;
+    box-shadow: 0 0 5px white, 0 0 10px white;
+}
+
+#ipad-overlay::after {
+    content: '';
+    position: absolute;
+    top: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 8px;
+    height: 8px;
+    background-color: #3b82f6;
+    border-radius: 50%;
+    box-shadow: 0 0 6px #3b82f6, 0 0 12px #3b82f6;
 }
 
 #monitor-overlay img {
@@ -146,61 +179,6 @@ html { scroll-behavior: smooth; }
     object-fit: contain;
     opacity: 0;
     transition: opacity 0.5s ease-in-out;
-}
-
-/* --- Estilos para Overlays de Video en 3D --- */
-#monitor-overlay, #ipad-overlay {
-    background: rgba(10, 10, 25, 0.6); /* Fondo oscuro semitransparente */
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    box-shadow:
-        inset 0 0 15px rgba(0, 0, 0, 0.8), /* Sombra interna para profundidad */
-        0 10px 25px rgba(0, 0, 0, 0.5);   /* Sombra externa para flotar */
-    overflow: hidden;
-    position: absolute;
-    backdrop-filter: blur(3px); /* Efecto de cristal esmerilado */
-    -webkit-backdrop-filter: blur(3px);
-}
-
-#monitor-overlay {
-    border-radius: 12px; /* Bordes ligeramente redondeados para el monitor */
-}
-
-#ipad-overlay {
-    border-radius: 24px; /* Bordes más redondeados para el iPad */
-    border-width: 3px;
-    border-color: rgba(200, 200, 220, 0.25);
-}
-
-/* --- Luces y Efectos Fosforescentes --- */
-@keyframes pulse-glow {
-    0%, 100% { box-shadow: 0 0 5px 2px rgba(255, 255, 255, 0.7); }
-    50% { box-shadow: 0 0 15px 5px rgba(255, 255, 255, 1); }
-}
-
-#monitor-overlay::after {
-    content: '';
-    position: absolute;
-    bottom: 8px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 20px;
-    height: 3px;
-    background-color: #fff;
-    border-radius: 2px;
-    animation: pulse-glow 2.5s infinite ease-in-out;
-}
-
-#ipad-overlay::before {
-    content: '';
-    position: absolute;
-    top: 12px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 6px;
-    height: 6px;
-    background-color: #fff;
-    border-radius: 50%;
-    box-shadow: 0 0 8px 3px rgba(255, 255, 255, 0.8);
 }
 
 #monitor-overlay img.fade-in {

--- a/js/main.js
+++ b/js/main.js
@@ -974,7 +974,7 @@ videosToLazyLoad.forEach(video => videoObserver.observe(video));
                 perspective: 500, rotateY: 2, rotateX: -2, skewX: -2
             };
             const ipad = {
-                top: 0.625, left: 0.675, width: 0.155, height: 0.342
+                bottom: 0.06, left: 0.665, width: 0.166, height: 0.342
             };
 
             // Apply styles to Monitor
@@ -985,7 +985,7 @@ videosToLazyLoad.forEach(video => videoObserver.observe(video));
             monitorOverlay.style.transform = `translateX(-50%) perspective(${monitor.perspective}px) rotateY(${monitor.rotateY}deg) rotateX(${monitor.rotateX}deg) skewX(${monitor.skewX}deg)`;
 
             // Apply styles to iPad
-            ipadOverlay.style.top = `${containerHeight * ipad.top}px`;
+            ipadOverlay.style.bottom = `${containerHeight * ipad.bottom}px`;
             ipadOverlay.style.left = `${containerWidth * ipad.left}px`;
             ipadOverlay.style.width = `${containerWidth * ipad.width}px`;
             ipadOverlay.style.height = `${containerHeight * ipad.height}px`;


### PR DESCRIPTION
This commit implements the final, detailed styling adjustments for the monitor and iPad overlays as specified by the user.

- The `border-radius` for `#monitor-overlay` is set to 12px and for `#ipad-overlay` to 18px to create more realistic device shapes.
- Custom indicator lights have been added to both overlays using `::after` pseudo-elements, complete with unique positioning, colors, and glow effects.
- The `overflow` property on the parent container has been set to `visible` to ensure the new indicator lights are not clipped.
- These changes provide the final, polished look for the device frames as requested.