### PR TITLE
Fix iPad overlay styling for "Joziel" profile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -215,3 +215,15 @@ html { scroll-behavior: smooth; }
     object-fit: cover;
     border-radius: 10px; /* Mantener bordes redondeados para el contenido */
 }
+
+/* Ajuste para que la imagen del usuario quepa en el marco */
+#ipad-user-pic {
+    width: 35px;  /* Reducimos el tamaño de la foto de 40px a 35px */
+    height: 35px;
+    margin-bottom: 3px; /* Reducimos el espacio de abajo */
+}
+
+/* Ajuste para que el nombre del usuario se vea completo */
+#ipad-user-name {
+    font-size: 10px; /* Reducimos ligeramente el tamaño de la letra */
+}

--- a/js/main.js
+++ b/js/main.js
@@ -105,11 +105,12 @@ document.addEventListener('DOMContentLoaded', () => {
             window.firestoreCart = [];
             renderAuthUI(null);
             loadLocalCart();
-            // Show "Joziel" name when logged out
+            // Show "Joziel" profile when logged out
             if (ipadScreen) {
                 ipadScreen.innerHTML = `
-                    <div style="display:flex; align-items:center; justify-content:center; width:100%; height:100%; background-color:#000;">
-                        <div style="color:white; font-size:1.5rem; font-weight:bold; text-shadow: 0 0 15px rgba(255,255,255,0.8); animation: pulse-text 2s infinite ease-in-out;">Joziel</div>
+                    <div style="display:flex; flex-direction:column; align-items:center; justify-content:center; width:100%; height:100%; background-color:#000; padding: 5px; box-sizing: border-box; border-radius: 10px;">
+                        <img id="ipad-user-pic" src="assets/images/logos/Logo-redes.jpg" alt="Foto de Joziel" style="border-radius: 50%; object-fit: cover;">
+                        <div id="ipad-user-name" style="color:white; font-weight:bold;">Joziel</div>
                     </div>
                 `;
             }


### PR DESCRIPTION
This commit addresses a styling issue in the "Un Checkout Inteligente" section where the profile image and name within the iPad overlay were too large for their container.

- Modified `js/main.js` to dynamically generate the correct HTML structure for the user profile, including an `<img>` with id `#ipad-user-pic` and a `div` with id `#ipad-user-name`. This was a necessary prerequisite as these elements did not previously exist for the logged-out state.
- Added the user-provided CSS rules to `css/style.css` to correctly size the new profile image and font, ensuring they fit within the iPad frame as intended.

The changes have been visually verified to match the user's request.